### PR TITLE
fix: resolve clippy warnings for production readiness

### DIFF
--- a/crates/cli/src/groups.rs
+++ b/crates/cli/src/groups.rs
@@ -153,7 +153,7 @@ mod tests {
 
     #[test]
     fn test_group_factory_default() {
-        let factory = GroupFactory::default();
+        let factory = GroupFactory;
         // Just ensure it can be created
         let _ = format!("{:?}", factory);
     }

--- a/crates/cli/src/routing.rs
+++ b/crates/cli/src/routing.rs
@@ -104,7 +104,7 @@ mod tests {
 
     #[test]
     fn test_router_factory_default() {
-        let factory = RouterFactory::default();
+        let factory = RouterFactory;
         let _ = format!("{:?}", factory);
     }
 }

--- a/crates/cli/src/validators.rs
+++ b/crates/cli/src/validators.rs
@@ -175,13 +175,13 @@ mod tests {
 
     #[test]
     fn test_validator_factory_default() {
-        let factory = ValidatorFactory::default();
+        let factory = ValidatorFactory;
         let _ = format!("{:?}", factory);
     }
 
     #[test]
     fn test_rate_limiter_factory_default() {
-        let factory = RateLimiterFactory::default();
+        let factory = RateLimiterFactory;
         let _ = format!("{:?}", factory);
     }
 }

--- a/crates/rpc/src/validator.rs
+++ b/crates/rpc/src/validator.rs
@@ -634,7 +634,7 @@ mod tests {
 
     #[test]
     fn test_noop_validator_default() {
-        let validator = NoopValidator::default();
+        let validator = NoopValidator;
         let request = make_request_no_params("eth_test");
         let result = validator.validate(request);
         assert!(result.is_valid());

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -61,12 +61,9 @@ fn test_basic_request_flow() {
 
     // 4. Validate the request
     let validator_chain = ValidatorChain::new();
-    match packet {
-        ParsedRequestPacket::Single(req) => {
-            let result = validator_chain.validate(req);
-            assert!(result.is_valid());
-        }
-        _ => {}
+    if let ParsedRequestPacket::Single(req) = packet {
+        let result = validator_chain.validate(req);
+        assert!(result.is_valid());
     }
 }
 


### PR DESCRIPTION
## Summary
- Replace `default()` with unit struct construction for unit structs (clippy::default_constructed_unit_structs)
- Use `if let` instead of `match` for single-pattern destructuring (clippy::single_match)

## Files Changed
- `crates/rpc/src/validator.rs` - NoopValidator
- `crates/cli/src/groups.rs` - GroupFactory
- `crates/cli/src/routing.rs` - RouterFactory
- `crates/cli/src/validators.rs` - ValidatorFactory, RateLimiterFactory
- `tests/integration_test.rs` - if-let cleanup

## Verification
- [x] `cargo clippy --workspace --all-targets` - no warnings
- [x] `cargo test --workspace` - all tests pass
- [x] `roxy-proxy --config example.toml --check` - config validation works