### PR TITLE
chore: add #[must_use] to error type constructors

### DIFF
--- a/crates/rpc/src/validator.rs
+++ b/crates/rpc/src/validator.rs
@@ -22,6 +22,7 @@ pub struct ValidationError {
 
 impl ValidationError {
     /// Create a new validation error.
+    #[must_use]
     pub fn new(code: i64, message: impl Into<String>) -> Self {
         Self { code, message: message.into() }
     }

--- a/crates/traits/src/codec.rs
+++ b/crates/traits/src/codec.rs
@@ -11,6 +11,7 @@ pub struct CodecError(pub String);
 
 impl CodecError {
     /// Create a new codec error.
+    #[must_use]
     pub fn new(msg: impl Into<String>) -> Self {
         Self(msg.into())
     }


### PR DESCRIPTION
## Summary

- Add `#[must_use]` attribute to `CodecError::new()` in `crates/traits/src/codec.rs`
- Add `#[must_use]` attribute to `ValidationError::new()` in `crates/rpc/src/validator.rs`

This ensures callers handle the returned error values rather than accidentally discarding them, consistent with other constructor methods in the codebase.

## Changes

Adds the `#[must_use]` attribute to two error type constructors that were missing it.