### PR TITLE
docs: add backticks for clippy doc_markdown lint

### DIFF
--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -198,7 +198,7 @@ impl Default for RateLimitConfig {
 /// Maps RPC methods to backend groups or blocks them entirely.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct RouteConfig {
-    /// Method name or prefix (e.g., "eth_call" or "eth_").
+    /// Method name or prefix (e.g., `eth_call` or `eth_`).
     pub method: String,
     /// Target group name or "block" to reject the method.
     pub target: String,

--- a/crates/rpc/src/codec.rs
+++ b/crates/rpc/src/codec.rs
@@ -227,7 +227,7 @@ impl<C: CodecConfig> RpcCodec<C> {
         &self.config
     }
 
-    /// Parse raw bytes into a ParsedRequestPacket, enforcing size limits.
+    /// Parse raw bytes into a `ParsedRequestPacket`, enforcing size limits.
     ///
     /// This parses the JSON and validates structure. Use this when you need
     /// to inspect the request method or parameters.
@@ -262,7 +262,7 @@ impl<C: CodecConfig> RpcCodec<C> {
         self.decode(bytes.as_ref())
     }
 
-    /// Serialize a ParsedResponsePacket to bytes.
+    /// Serialize a `ParsedResponsePacket` to bytes.
     ///
     /// # Errors
     ///
@@ -276,7 +276,7 @@ impl<C: CodecConfig> RpcCodec<C> {
         Ok(Bytes::from(json))
     }
 
-    /// Serialize a single ParsedResponse to bytes.
+    /// Serialize a single `ParsedResponse` to bytes.
     ///
     /// # Errors
     ///
@@ -298,7 +298,7 @@ impl<C: CodecConfig> RpcCodec<C> {
         Ok(Bytes::from(json))
     }
 
-    /// Parse raw bytes into a ParsedRequestPacket.
+    /// Parse raw bytes into a `ParsedRequestPacket`.
     fn parse_request_packet(&self, bytes: &[u8]) -> Result<ParsedRequestPacket, CodecError> {
         // Trim leading whitespace to check if it starts with [ (batch) or { (single)
         let trimmed = bytes.iter().skip_while(|b| b.is_ascii_whitespace()).copied().next();

--- a/crates/traits/README.md
+++ b/crates/traits/README.md
@@ -5,7 +5,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 Core trait definitions for Roxy components including Backend, Cache,
-RateLimiter, LoadBalancer, and runtime abstractions for spawning,
+`RateLimiter`, `LoadBalancer`, and runtime abstractions for spawning,
 clocks, and metrics.
 
 ## License


### PR DESCRIPTION
## Summary
- Add backticks around type names in docstrings and README for clippy pedantic `doc_markdown` lint compliance
- Fixes warnings in `crates/traits/README.md` (RateLimiter, LoadBalancer)
- Fixes warnings in `crates/config/src/lib.rs` (eth_call)
- Fixes warnings in `crates/rpc/src/codec.rs` (ParsedRequestPacket, ParsedResponsePacket, ParsedResponse)